### PR TITLE
Update strict CSP link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       We believe that a carefully-crafted
       <a href="https://w3c.github.io/webappsec-csp/">Content Security Policy</a>
       can help protect web applications from injection attacks that would otherwise lead to script
-      execution. <a href="https://csp.withgoogle.com/docs/strict-csp.html">Strict CSP</a> is a
+      execution. <a href="https://web.dev/strict-csp/">Strict CSP</a> is a
       reasonable approach, one which we'd like to encourage.
     </p>
     <p>


### PR DESCRIPTION
https://csp.withgoogle.com/docs/strict-csp.html was deprecated in favour of https://web.dev/strict-csp